### PR TITLE
Add TurnService attempt limit tests

### DIFF
--- a/script.js
+++ b/script.js
@@ -2026,6 +2026,12 @@ let turnData = {};
 let history = [];
 let isCreationMode = false;
 
+// Helpers exposed for unit tests
+function getKingdom() { return kingdom; }
+function setKingdom(k) { kingdom = k; }
+function getTurnData() { return turnData; }
+function setTurnData(t) { turnData = t; }
+
 // ==========================================
 // UI RENDERING COMPONENTS
 // ==========================================
@@ -3800,5 +3806,13 @@ if (typeof document !== "undefined") {
 }
 
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { KingdomService, AVAILABLE_STRUCTURES };
+  module.exports = {
+    KingdomService,
+    AVAILABLE_STRUCTURES,
+    TurnService,
+    getKingdom,
+    setKingdom,
+    getTurnData,
+    setTurnData
+  };
 }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -1,5 +1,19 @@
 const assert = require('assert');
-const { KingdomService, AVAILABLE_STRUCTURES } = require('../script');
+// Import internal services and helpers from the main script
+const {
+  KingdomService,
+  AVAILABLE_STRUCTURES,
+  TurnService,
+  getKingdom,
+  setKingdom,
+  setTurnData,
+  getTurnData
+} = require('../script');
+
+// Provide very small stubs for browser dependent globals used by the services
+global.UIkit = { notification: () => {}, modal: { confirm: () => Promise.resolve({}), alert: () => Promise.resolve({}) } };
+global.UI = { renderTurnTracker: () => {}, renderAll: () => {} };
+global.localStorage = { getItem: () => null, setItem: () => {} };
 
 function createSettlement(gridSize, lots) {
   return { gridSize, lots };
@@ -32,8 +46,98 @@ function testOvercrowding() {
   assert.strictEqual(KingdomService.isSettlementOvercrowded(settlement), false, 'adding residential resolves overcrowding');
 }
 
+// ----- new tests for attempt limits -----
+function setupBasicKingdom(level, structures = []) {
+  const lots = structures.map(name => ({ buildingId: 1, isOrigin: true, structureName: name }));
+  setKingdom({
+    level,
+    size: 1,
+    fame: 0,
+    unrest: 0,
+    food: 10,
+    armies: [],
+    farmlandHexes: 0,
+    leaders: {},
+    capital: 'Cap',
+    settlements: [{ name: 'Cap', gridSize: 1, lots }]
+  });
+}
+
+function testCanAttemptClaimHex() {
+  setupBasicKingdom(1);
+  setTurnData({ claimHexAttempts: 0 });
+  assert.strictEqual(TurnService.canAttemptClaimHex(), true, 'level 1 start');
+
+  setTurnData({ claimHexAttempts: 1 });
+  assert.strictEqual(TurnService.canAttemptClaimHex(), false, 'level 1 max 1 attempt');
+
+  setupBasicKingdom(8);
+  setTurnData({ claimHexAttempts: 1 });
+  assert.strictEqual(TurnService.canAttemptClaimHex(), true, 'level 8 allows two');
+
+  setTurnData({ claimHexAttempts: 2 });
+  assert.strictEqual(TurnService.canAttemptClaimHex(), false, 'level 8 after two attempts');
+}
+
+function testCanAttemptLeadershipActivity() {
+  // level below threshold with no special buildings
+  setupBasicKingdom(5);
+  setTurnData({ leadershipActivitiesUsed: 1 });
+  assert.strictEqual(TurnService.canAttemptLeadershipActivity(), true, 'level 5 base allows 2');
+
+  setTurnData({ leadershipActivitiesUsed: 2 });
+  assert.strictEqual(TurnService.canAttemptLeadershipActivity(), false, 'level 5 after two');
+
+  // higher level increases base
+  setupBasicKingdom(12);
+  setTurnData({ leadershipActivitiesUsed: 2 });
+  assert.strictEqual(TurnService.canAttemptLeadershipActivity(), true, 'level 12 base 3');
+
+  setTurnData({ leadershipActivitiesUsed: 3 });
+  assert.strictEqual(TurnService.canAttemptLeadershipActivity(), false, 'level 12 after three');
+
+  // Town Hall in capital grants +1
+  setupBasicKingdom(12, ['Town Hall']);
+  setTurnData({ leadershipActivitiesUsed: 3 });
+  assert.strictEqual(TurnService.canAttemptLeadershipActivity(), true, 'Town Hall allows extra');
+
+  setTurnData({ leadershipActivitiesUsed: 4 });
+  assert.strictEqual(TurnService.canAttemptLeadershipActivity(), false, 'Town Hall max reached');
+}
+
+function testPhaseOrder() {
+  setupBasicKingdom(1);
+  setTurnData({
+    rolledResources: false,
+    paidConsumption: false,
+    appliedUnrest: false,
+    eventChecked: false,
+    claimHexAttempts: 0,
+    leadershipActivitiesUsed: 0,
+    regionActivitiesUsed: 0,
+    civicActivitiesUsed: 0,
+    turnResourcePoints: 0,
+    turnUnrest: 0
+  });
+
+  // cannot pay consumption before rolling resources
+  TurnService.payConsumption();
+  assert.strictEqual(getTurnData().paidConsumption, false, 'payConsumption blocked');
+
+  // cannot apply upkeep before paying consumption
+  TurnService.applyUpkeepEffects();
+  assert.strictEqual(getTurnData().appliedUnrest, false, 'applyUpkeepEffects blocked');
+
+  // cannot check event before applying unrest
+  TurnService.checkForEvent();
+  assert.strictEqual(getTurnData().eventChecked, false, 'checkForEvent blocked');
+}
+
 try {
   testOvercrowding();
+  testCanAttemptClaimHex();
+  testCanAttemptLeadershipActivity();
+  testPhaseOrder();
   console.log('All tests passed.');
 } catch (err) {
   console.error('Test failed:', err.message);


### PR DESCRIPTION
## Summary
- expose `TurnService` internals for tests
- add helpers to set/get kingdom and turn data
- expand test suite with attempt limit and phase order checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687426e1b1b4832f9fa5b51a040561d0