### PR TITLE
Add Fame spending utilities and infamy reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -1652,8 +1652,9 @@ calculateControlDC() {
   },
 
   spendAllFameToPreventRuin() {
-    const spent = kingdom.fame;
+    const spent = (kingdom.fame || 0) + (kingdom.infamy || 0);
     kingdom.fame = 0;
+    kingdom.infamy = 0;
     return spent > 0;
   },
 
@@ -2025,6 +2026,7 @@ const TurnService = {
         if (rpToTreasury > 0) kingdom.treasury += rpToTreasury;
         kingdom.unrest = turnData.turnUnrest || 0;
         kingdom.fame = 0;
+        kingdom.infamy = 0;
         if (rpToXP > 0) {
           ErrorHandler.showSuccess(`${rpToXP} unspent RP converted to Kingdom XP.`);
         }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -88,6 +88,7 @@ function setupBasicKingdom(level, structures = []) {
     level,
     size: 1,
     fame: 0,
+    infamy: 0,
     unrest: 0,
     food: 10,
     armies: [],
@@ -414,16 +415,19 @@ function testRPConversion() {
 function testFameSpending() {
   setupBasicKingdom(1);
   getKingdom().fame = 2;
+  getKingdom().infamy = 1;
   assert.strictEqual(KingdomService.spendFameForReroll(), true, 'reroll spends fame');
   assert.strictEqual(getKingdom().fame, 1, 'fame decreased by 1');
-  assert.strictEqual(KingdomService.spendAllFameToPreventRuin(), true, 'spend all fame');
+  assert.strictEqual(KingdomService.spendAllFameToPreventRuin(), true, 'spend all fame/infamy');
   assert.strictEqual(getKingdom().fame, 0, 'fame cleared');
+  assert.strictEqual(getKingdom().infamy, 0, 'infamy cleared');
   assert.strictEqual(KingdomService.spendFameForReroll(), false, 'cannot spend when none');
 }
 
 function testFameResetAfterTurn() {
   setupBasicKingdom(1);
   getKingdom().fame = 3;
+  getKingdom().infamy = 2;
   getKingdom().ruins = {
     corruption: { points: 0, penalty: 0, threshold: 10 },
     crime: { points: 0, penalty: 0, threshold: 10 },
@@ -442,6 +446,7 @@ function testFameResetAfterTurn() {
   });
   TurnService.saveTurn();
   assert.strictEqual(getKingdom().fame, 0, 'fame reset after save');
+  assert.strictEqual(getKingdom().infamy, 0, 'infamy reset after save');
 }
 
 function createSkills(names) {


### PR DESCRIPTION
## Summary
- add helper to spend all Fame and Infamy to prevent Ruin
- reset infamy at the end of each turn
- extend unit tests to cover infamy clearing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687521be8e50832fa6642a4c18a02ba6