### PR TITLE
Update leader status bonuses

### DIFF
--- a/script.js
+++ b/script.js
@@ -1527,9 +1527,9 @@ calculateControlDC() {
     });
     if (!invested) return 0;
 
-    if (kingdom.level >= 15) return 3;
-    if (kingdom.level >= 5) return 2;
-    return 1;
+    if (kingdom.level >= 16) return 3;
+    if (kingdom.level >= 8) return 2;
+    return 1; // levels 1-7
   },
 
   checkFeatPrerequisites(feat) {

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -475,8 +475,11 @@ function testStatusBonus() {
   const mods = KingdomService.calculateSkillModifiers();
   assert.strictEqual(mods.Warfare, 1, 'status bonus applied to skill');
 
-  getKingdom().level = 10;
-  assert.strictEqual(KingdomService.getStatusBonusForAbility('loyalty'), 2, 'level 10 invested gives +2');
+  getKingdom().level = 7;
+  assert.strictEqual(KingdomService.getStatusBonusForAbility('loyalty'), 1, 'level 7 invested gives +1');
+
+  getKingdom().level = 8;
+  assert.strictEqual(KingdomService.getStatusBonusForAbility('loyalty'), 2, 'level 8 invested gives +2');
 
   getKingdom().level = 16;
   assert.strictEqual(KingdomService.getStatusBonusForAbility('loyalty'), 3, 'level 16 invested gives +3');


### PR DESCRIPTION
## Summary
- invested leader status bonuses now increase at level 8 and 16 instead of 5 and 15
- updated corresponding unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875311cc984832fb63047ab4c44e757