### PR TITLE
Add QuickActions bar and keyboard shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
             <p class="uk-text-lead">A web application for managing your Pathfinder 2e kingdom, based on your Google Sheet.</p>
         </header>
 
+        <div id="quick-actions-bar" class="uk-margin-bottom"></div>
+
         <!-- Main Tab Navigation -->
 <ul id="main-tabs" uk-tab>
     <li class="uk-active"><a href="#">Kingdom Sheet</a></li>

--- a/script.js
+++ b/script.js
@@ -2861,8 +2861,52 @@ const UI = {
     this.renderHistory();
     this.renderTurnTracker();
     this.renderSettlements();
-    this.renderArmies();
+  this.renderArmies();
 this.renderKingdomManagement();
+  }
+};
+
+const QuickActions = {
+  render() {
+    return `
+      <div class="uk-button-group">
+        <button id="qa-collect" class="uk-button uk-button-primary">Collect Resources</button>
+        <button id="qa-consume" class="uk-button uk-button-primary">Pay Consumption</button>
+        <button id="qa-events" class="uk-button uk-button-primary">Check Events</button>
+        <button id="qa-auto" class="uk-button uk-button-secondary">Auto-Optimize Turn</button>
+      </div>`;
+  },
+
+  init() {
+    if (typeof document === 'undefined') return;
+    const bar = document.getElementById('quick-actions-bar');
+    if (!bar) return;
+    bar.innerHTML = this.render();
+    bar.addEventListener('click', (e) => {
+      const id = e.target.id;
+      if (id === 'qa-collect') TurnService.rollResources();
+      else if (id === 'qa-consume') TurnService.payConsumption();
+      else if (id === 'qa-events') TurnService.checkForEvent();
+      else if (id === 'qa-auto') {
+        TurnService.rollResources();
+        TurnService.payConsumption();
+        TurnService.applyUpkeepEffects();
+        TurnService.checkForEvent();
+      }
+    });
+    document.addEventListener('keydown', this.handleShortcuts);
+  },
+
+  handleShortcuts(e) {
+    if (!e.ctrlKey && !e.metaKey) return;
+    const key = e.key.toLowerCase();
+    if (key === 's') {
+      e.preventDefault();
+      SaveService.save();
+    } else if (key === 'e') {
+      e.preventDefault();
+      TurnService.saveTurn();
+    }
   }
 };
 
@@ -4403,7 +4447,10 @@ function initializeApplication() {
   ErrorHandler.withErrorHandling(() => {
     console.log(`Initializing Kingdom Tracker v${CONFIG.VERSION}`);
     SaveService.load();
-    if (typeof document !== 'undefined') UI.renderAll();
+    if (typeof document !== 'undefined') {
+      UI.renderAll();
+      QuickActions.init();
+    }
     TurnService.clearTurn();
     EventHandlers.initEventListeners();
     CreationService.calculateAndRenderScores();
@@ -4459,6 +4506,8 @@ if (typeof module !== "undefined" && module.exports) {
     setTurnData,
     MilestoneService,
     StructurePreview,
-    SettlementPlanner
+    SettlementPlanner,
+    SaveService,
+    QuickActions
   };
 }

--- a/tests/runTests.js
+++ b/tests/runTests.js
@@ -11,7 +11,9 @@ const {
   getKingdom,
   setKingdom,
   setTurnData,
-  getTurnData
+  getTurnData,
+  SaveService,
+  QuickActions
 } = require('../script');
 
 // Provide very small stubs for browser dependent globals used by the services
@@ -542,6 +544,19 @@ function testCalculateOptimalLayout() {
   });
 }
 
+function testShortcutHandlers() {
+  let saved = false;
+  let ended = false;
+  SaveService.save = () => { saved = true; };
+  TurnService.saveTurn = () => { ended = true; };
+
+  QuickActions.handleShortcuts({ ctrlKey: true, key: 's', preventDefault() {} });
+  assert.strictEqual(saved, true, 'Ctrl+S triggers save');
+
+  QuickActions.handleShortcuts({ ctrlKey: true, key: 'E', preventDefault() {} });
+  assert.strictEqual(ended, true, 'Ctrl+E triggers save turn');
+}
+
 try {
   testOvercrowding();
   testCanAttemptClaimHex();
@@ -561,6 +576,7 @@ try {
   testEventXP();
   testPreviewDoesNotModify();
   testCalculateOptimalLayout();
+  testShortcutHandlers();
   console.log('All tests passed.');
 } catch (err) {
   console.error('Test failed:', err);


### PR DESCRIPTION
## Summary
- render a quick actions bar for common turn actions
- implement `QuickActions` module to execute turn-service functions
- bind Ctrl+S to saving and Ctrl+E to ending the turn
- test that the keyboard shortcuts trigger the right service methods

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875448c96e4832fb9c3230059f2428a