### PR TITLE
Add level up handler to sheet

### DIFF
--- a/script.js
+++ b/script.js
@@ -4155,9 +4155,18 @@ initEventListeners() {
         if(kingdomSheetContent) {
             kingdomSheetContent.addEventListener("click", (e) => {
                 try {
-                    const resourceButton = e.target.closest("button[data-resource]");
+                    const target = e.target.closest('a, button');
+                    if (!target) return;
+
+                    const resourceButton = target.closest("button[data-resource]");
                     if (resourceButton) {
                         this.handleResourceUpdate(resourceButton.dataset.resource, resourceButton.dataset.action);
+                        return;
+                    }
+
+                    if (target.id === 'kingdom-level-up-btn') {
+                        this.handleLevelUp();
+                        return;
                     }
                 } catch (error) {
                     console.error("Error in kingdom sheet click handler:", error);


### PR DESCRIPTION
## Summary
- detect clicks on `#kingdom-level-up-btn` within the kingdom sheet
- invoke `handleLevelUp` so the sheet works like the management view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875551a0838832fa5c6c4ae22b6422e